### PR TITLE
Publish to www.andrewkroh.com bucket instead of andrewkroh.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ deps:
 	bundler install --path vendor/cache
 
 prod:
-	aws s3 sync _site/ s3://andrewkroh.com --acl public-read --delete
+	aws s3 sync _site/ s3://www.andrewkroh.com --delete
 
 image:
 	docker build -t www_andrewkroh_com .


### PR DESCRIPTION
Moved buckets around so that andrewkroh.com on S3 can simply
redirect to www.andrewkroh.com. And andrewkroh.com can be an
AWS Route53 Alias record.