### PR TITLE
Add Dependabot and improve AWS authentication security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 3

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,7 +7,13 @@ on:
       - staging
   pull_request:
     branches:
+      - main
+      - master
       - staging
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   build:
@@ -26,10 +32,9 @@ jobs:
 
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Publish site


### PR DESCRIPTION
Configure Dependabot to automatically update GitHub Actions dependencies. Update Jekyll workflow to use OIDC with role assumption instead of static AWS credentials for improved security.